### PR TITLE
Correct misspelling of architectures field name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Serial Terminal library for Arduino
 paragraph=This is a universal Serial Terminal library for Arduino to parse ASCII commands and arguments.
 category=Communication
 url=https://github.com/Erriez/ErriezSerialTerminal
-architecture=*
+architectures=*


### PR DESCRIPTION
The correct spelling of the field name is architectures, not architecture.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format