### PR TITLE
Added backspace support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ term.clearBuffer();
 
 Optional: Allow for any entered charecters to be printed back to the Serial interface.
 This is useful for terminal programs like PuTTY.
+Supports both backspace characters, ^H and ^127.
 
 ```c++
 term.setSerialEcho(true); //Enable Character Echoing

--- a/src/ErriezSerialTerminal.cpp
+++ b/src/ErriezSerialTerminal.cpp
@@ -162,15 +162,24 @@ void SerialTerminal::readSerial()
             }
 
             clearBuffer();
+        // either ^H og 127 backspace chars
+        } else if (c == '\b' || c == 127) {
+            if (_rxBufferIndex > 0) {
+                _rxBufferIndex--;
+                _rxBuffer[_rxBufferIndex] = '\0';
+                if (doCharEcho) {
+                    Serial.print("\b \b"); // 1 char back, space, 1 char back
+                }
+            }
         } else if (isprint(c)) {
             // Store printable characters in serial receive buffer
             if (_rxBufferIndex < ST_RX_BUFFER_SIZE) {
                 _rxBuffer[_rxBufferIndex++] = c;
                 _rxBuffer[_rxBufferIndex] = '\0';
-            }
-            //Echo received char
-            if (doCharEcho) {
-                Serial.print(c);
+                //Echo received char
+                if (doCharEcho) {
+                    Serial.print(c);
+                }
             }
         }
     }


### PR DESCRIPTION
I've implemented simple backspace support.

Should work both with and without echoing. So far I've tested in PuTTy and Teraterm. In PuTTy it's easy to test with the two types of backspace chars ^H and ^127 (go to Terminal->Keyboard->Backspace key). Both seem to work as expected.

I've had to move the echoing inside the check for buffer overflow, otherwise the behaviour was not as expected when the input exceeded the length of the buffer.